### PR TITLE
Persist through re-auth

### DIFF
--- a/html/BecomeOriginalUser.html
+++ b/html/BecomeOriginalUser.html
@@ -3,6 +3,7 @@
 if (exists $session{RT_Extension_BecomeUser_OriginalUser}){
     $session{CurrentUser} = $session{RT_Extension_BecomeUser_OriginalUser};
     undef $session{RT_Extension_BecomeUser_OriginalUser};
+    undef $session{RT_Extension_BecomeUser_NewUser};
 }
 </%INIT>
 <h1>you are now back at your original account with id <%$session{CurrentUser}->id %></h1>

--- a/html/BecomeUser.html
+++ b/html/BecomeUser.html
@@ -15,7 +15,7 @@ if ( $session{CurrentUser}->HasRight(
     }
     else {
         $session{RT_Extension_BecomeUser_OriginalUser} = $session{CurrentUser};
-        $session{CurrentUser} = $u;
+        $session{RT_Extension_BecomeUser_NewUser} = $session{CurrentUser} = $u;
         $session{CurrentUser}->_BuildTableAttributes;
 
         $m->out("<h1>you are now user ".$session{CurrentUser}->Name." (id: $id )</h1>");

--- a/html/Callbacks/RT-Extension-BecomeUser/autohandler/Auth
+++ b/html/Callbacks/RT-Extension-BecomeUser/autohandler/Auth
@@ -1,0 +1,7 @@
+<%init>
+if ($session{RT_Extension_BecomeUser_NewUser}){
+    if ($session{CurrentUser}->Id != $session{RT_Extension_BecomeUser_NewUser}->Id){
+        $session{CurrentUser} = $session{RT_Extension_BecomeUser_NewUser};
+    }
+}
+</%init>


### PR DESCRIPTION
When using WebRemoteUserAuth or other external authentication,
$session{CurrentUser} may be reset on page load, so our override
has no effect. This checks our current user id after the reset,
and overrides it then if necessary.

fixes #1 